### PR TITLE
Use `partial` definitions for monkey-patched Web IDL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -576,35 +576,25 @@ It is exposed to the Javascript [=HTMLIFrameElement=] interface:
 
 <div class="monkey-patch">
 <pre class="idl" highlight="idl">
-[Exposed=Window]
-interface <a>HTMLIFrameElement</a> : <a>HTMLElement</a> {
-  // [...]
-  attribute boolean <a lt="dom-iframe-credentialless">credentialless</a>;
-  // [...]
+partial interface HTMLIFrameElement {
+  attribute boolean credentialless;
 };
 </pre>
 
-<p>The IDL attributes <dfn export lt="dom-iframe-credentialless">credentialless</dfn>,
+<p>The IDL attributes <dfn attribute for="HTMLIFrameElement">credentialless</dfn>,
 must <a>reflect</a> the respective content attributes of the same name.</p>
 
 </div>
 
 ### The Window attribute ### {#spec-window-attribute}
 
-Add a read-only constant {{Window/credentialless}} attribute
+Add a read-only constant <dfn attribute for="Window">credentialless</dfn> attribute
 to the [=Window=] object.
 
 <div class="monkey-patch">
 <pre class="idl" highlight="idl">
-[
-  Global=<a>Window</a>,
-  Exposed=<a>Window</a>,
-  <a>LegacyUnenumerableNamedProperties</a>
-]
-interface <a>Window</a> : <a>EventTarget</a> {
-  // ...
-  readonly attribute boolean <a>credentialless</a>;
-  // ...
+partial interface Window {
+  readonly attribute boolean credentialless;
 };
 </pre>
 </div>


### PR DESCRIPTION
The `partial` Web IDL keyword allows to extend the base `HTMLIFrameElement` and `Window` interfaces properly, without creating duplicate definitions. This is needed to be able to merge the IDL blocks with those of the HTML spec.

(The update also fixes the actual definition of the attribute in prose to leverage Bikeshed's cross-referencing capabilities)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/anonymous-iframe/pull/21.html" title="Last updated on Dec 1, 2023, 2:16 PM UTC (1a86167)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/anonymous-iframe/21/f0166a1...tidoust:1a86167.html" title="Last updated on Dec 1, 2023, 2:16 PM UTC (1a86167)">Diff</a>